### PR TITLE
Pasting into quill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/bundle.js
 src/utils/env.ts
 /node_modules/
 dist/
+dist/bundle.js

--- a/src/controls/InfoSectionManager.ts
+++ b/src/controls/InfoSectionManager.ts
@@ -177,12 +177,46 @@ export class InfoSectionManager {
     });
     modal.open();
 
+    const Delta = Quill.import('delta');
     const quill = new Quill("#editor", {
+      formats: [
+        'bold',
+        'italic',
+        'underline',
+        'link',
+        'list'
+      ],
       modules: {
         toolbar: [
           ["bold", "italic", "underline", "link"],
           [{ list: "ordered" }, { list: "bullet" }],
         ],
+        clipboard: {
+          matchers: [
+            [ 
+              Node.ELEMENT_NODE,
+              (node: Node, delta: any) => {
+                return delta.compose(new Delta().retain(delta.length(), {
+                  background: false,
+                  color: false,
+                  font: false,
+                  code: false,
+                  size: false,
+                  strike: false,
+                  script: false,
+                  blockquote: false,
+                  header: false,
+                  indent: false,
+                  align: false,
+                  direction: false,
+                  formula: false,
+                  image: false,
+                  video: false
+                }));
+              }
+            ] 
+          ]
+        }
       },
       theme: "snow",
       placeholder: "Start typing here...",

--- a/src/controls/editor/ContentDataUi.ts
+++ b/src/controls/editor/ContentDataUi.ts
@@ -150,12 +150,46 @@ export class ContentDataUi {
       });
       modal.open();
 
+      const Delta = Quill.import('delta');
       const quill = new Quill("#editor", {
+        formats: [
+          'bold',
+          'italic',
+          'underline',
+          'link',
+          'list'
+        ],
         modules: {
           toolbar: [
             ["bold", "italic", "underline", "link"],
             [{ list: "ordered" }, { list: "bullet" }],
           ],
+          clipboard: {
+            matchers: [
+              [ 
+                Node.ELEMENT_NODE,
+                (node: Node, delta: any) => {
+                  return delta.compose(new Delta().retain(delta.length(), {
+                    background: false,
+                    color: false,
+                    font: false,
+                    code: false,
+                    size: false,
+                    strike: false,
+                    script: false,
+                    blockquote: false,
+                    header: false,
+                    indent: false,
+                    align: false,
+                    direction: false,
+                    formula: false,
+                    image: false,
+                    video: false
+                  }));
+                }
+              ] 
+            ]
+          }
         },
         theme: "snow",
         placeholder: "Start typing here...",


### PR DESCRIPTION
Text behaviour from Google docs that cannot be created in AB
copying text from google docs into the AB Description editor, retains formatting of the text in size, colour and more.